### PR TITLE
Fix bearing formula

### DIFF
--- a/V6/antenna_dualtracker_GUI_v6.0.py
+++ b/V6/antenna_dualtracker_GUI_v6.0.py
@@ -885,7 +885,7 @@ def bearing(trackerLat, trackerLon, remoteLat, remoteLon):
         dLon = math.radians(remoteLon-trackerLon)       # delta longitude in radians
         
         y = math.sin(dLon)*math.cos(math.radians(remoteLat))
-        x = math.cos(math.radians(trackerLat))*math.sin(math.radians(remoteLat))-math.sin(math.radians(trackerLat))*math.cos(math.radians(remoteLat))*math.cos(dLat)
+        x = math.cos(math.radians(trackerLat))*math.sin(math.radians(remoteLat))-math.sin(math.radians(trackerLat))*math.cos(math.radians(remoteLat))*math.cos(dLon)
         tempBearing = math.degrees(math.atan2(y,x))     # returns the bearing from true north
         if (tempBearing < 0):
                 tempBearing = tempBearing + 360


### PR DESCRIPTION
Bearing formula wrong. it should be 
        θ = atan2(sin(Δlong)*cos(lat2),
                  cos(lat1)*sin(lat2) − sin(lat1)*cos(lat2)*cos(Δlong))
See http://www.movable-type.co.uk/scripts/latlong.html

Here is a gist with an example the error in the code makes the calculation off by about a degree. The last three lines of the gist are the sample output.
https://gist.github.com/tylerburnham42/3a501b64935a792d40ea6bf71e2d583f

 This site was the cited source code of the formula. Using the calculator at the top I got the third number to compare. 
http://www.movable-type.co.uk/scripts/latlong.html

Here is a screenshot of the result. 
http://imgur.com/vkL3JlK

Here is a screenshot of the correct formula from:
http://www.movable-type.co.uk/scripts/latlong.html
http://imgur.com/X73kFqE